### PR TITLE
Change template in case noting found for query.

### DIFF
--- a/stocksearch/website/templates/search.html
+++ b/stocksearch/website/templates/search.html
@@ -19,10 +19,14 @@
 
     </div>
 </header>
+{%  if not results_amount %}
+<h2>Nothing found for <strong>{{ query }}</strong></h2>
+{% else %}
 <h2>{{ results_amount }} Results for <strong>{{ query }}</strong>:</h2>
 <ul class="photos">
 {% include "_images.html" %}
 </ul>
+{% endif %}
 {% if not last_page %}
   <button class="main-button load-more">Load more results</button>
 {% endif %}


### PR DESCRIPTION
"nothig found for `void`" is better than
"0 Results for `void`:"
